### PR TITLE
Only push image on master

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -11,6 +11,7 @@ steps:
           image: koalaman/shellcheck-alpine
   - wait
   - name: Build and publish k8s-buildkite-agent container image
+    branches: 'master'
     agents:
       queue: default
       os: linux


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Only build and push docker image on master. This prevents PR's to accidentally push images. We should migrate to github actions as well but that's for another time.

### Related Issues

List related issues here
