### PR TITLE
Fix logs duplication

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -20,11 +20,12 @@ function cleanup {
 trap cleanup EXIT
 
 function tail_logs {
-  # logs will be failing until they're available for streaming, once available we actually start streaming them.
-  while ! kubectl logs --tail 0 --limit-bytes 1 "job/${job_name}" > /dev/null 2>&1; do sleep 0.2; done
+  # logs will be failing until they're available for streaming, once available — we actually start attempting to stream them.
+  while ! kubectl logs --tail 0 --limit-bytes 32 "job/${job_name}" > /dev/null 2>&1; do sleep 0.2; done
 
-  # It can fail even after we get the first result, so run it in loop (potentially allowing log to be displayed multiple times, but chance is low).
-  # Example of a failure: "Error from server (BadRequest): container "step" in pod "somepod" is waiting to start: PodInitializing"
+  # Run kubectl logs --follow in a loop since it can still fail:
+  #   1) It can fail due to pod not being initialized yet: "Error from server (BadRequest): container "step" in pod "somepod" is waiting to start: PodInitializing"
+  #   2) It can fail mid-streaming, in this case we unfortunately will display logs multiple times (partially).
   while ! kubectl logs --follow "job/${job_name}" 2>/dev/null; do sleep 0.2; done
 }
 

--- a/hooks/command
+++ b/hooks/command
@@ -19,12 +19,10 @@ function cleanup {
 }
 trap cleanup EXIT
 
-
 function tail_logs {
-  while true ; do
-    stdbuf -o0 -e0 kubectl logs -f "job/${job_name}" 2>>/dev/null || true
-    sleep 0.2
-  done
+  # logs will be failing until they're available for streaming, once available we actually start streaming them.
+  while ! kubectl logs --tail 0 --limit-bytes 1 "job/${job_name}" > /dev/null 2>&1; do sleep 0.2; done
+  kubectl logs --follow "job/${job_name}"
 }
 
 echo "--- :kubernetes: Starting Kubernetes Job"

--- a/hooks/command
+++ b/hooks/command
@@ -13,19 +13,33 @@ fi
 ((timeout=BUILDKITE_TIMEOUT*60))
 export BUILDKITE_TIMEOUT
 
+readonly job_logs_snapshot_file="$(mktemp)"
+
 function cleanup {
   # Delete all jobs older than a day
   kubectl delete job "$(kubectl get job -l buildkite/plugin=k8s | awk 'match($4,/[0-9]+d/) {print $1}')" 2>/dev/null || true
+  rm -f "$job_logs_snapshot_file"
 }
 trap cleanup EXIT
 
 function tail_logs {
   # logs will be failing until they're available for streaming, once available — we actually start attempting to stream them.
-  while ! timeout 5 kubectl logs --limit-bytes 32 "job/${job_name}"  > /dev/null 2>&1; do sleep 0.2; done
+  while ! timeout 5 kubectl logs --limit-bytes 1024 "job/${job_name}" > "$job_logs_snapshot_file" 2>/dev/null;
+  do
+    # If output is not empty we should start attempting to stream the logs.
+    # Without this check streaming can end up not getting any result (probably due to some race in k8s).
+    # Keep looping otherwise since empty output means that there is no useful log to display so we're not losing information.
+    if [[ -n "$(cat "$job_logs_snapshot_file")" ]]; then
+      break
+    else
+      sleep 0.2
+    fi
+  done
 
-  # Run kubectl logs --follow in a loop since it can still fail:
+  # Run kubectl logs --follow in a loop since it can fail:
   #   1) It can fail due to pod not being initialized yet: "Error from server (BadRequest): container "step" in pod "somepod" is waiting to start: PodInitializing"
   #   2) It can fail mid-streaming, in this case we unfortunately will display logs multiple times (partially).
+  #   3) It can hang not getting any result, but that's why we check for contents in a loop above.
   while ! kubectl logs --follow "job/${job_name}" 2>/dev/null; do sleep 0.2; done
 }
 

--- a/hooks/command
+++ b/hooks/command
@@ -21,7 +21,7 @@ trap cleanup EXIT
 
 function tail_logs {
   # logs will be failing until they're available for streaming, once available — we actually start attempting to stream them.
-  while ! kubectl logs --tail 0 --limit-bytes 32 "job/${job_name}" > /dev/null 2>&1; do sleep 0.2; done
+  while ! timeout 5 kubectl logs --tail 0 --limit-bytes 1 "job/${job_name}"  > /dev/null 2>&1; do sleep 0.2; done
 
   # Run kubectl logs --follow in a loop since it can still fail:
   #   1) It can fail due to pod not being initialized yet: "Error from server (BadRequest): container "step" in pod "somepod" is waiting to start: PodInitializing"

--- a/hooks/command
+++ b/hooks/command
@@ -22,7 +22,9 @@ trap cleanup EXIT
 function tail_logs {
   # logs will be failing until they're available for streaming, once available we actually start streaming them.
   while ! kubectl logs --tail 0 --limit-bytes 1 "job/${job_name}" > /dev/null 2>&1; do sleep 0.2; done
-  kubectl logs --follow "job/${job_name}"
+
+  # It can fail even after we get the first result, so run it in loop (potentially allowing log to be displayed multple times, but chance is low).
+  while ! kubectl logs --follow "job/${job_name}"; do sleep 0.2; done
 }
 
 echo "--- :kubernetes: Starting Kubernetes Job"

--- a/hooks/command
+++ b/hooks/command
@@ -21,7 +21,7 @@ trap cleanup EXIT
 
 function tail_logs {
   # logs will be failing until they're available for streaming, once available — we actually start attempting to stream them.
-  while ! timeout 5 kubectl logs --tail 0 --limit-bytes 1 "job/${job_name}"  > /dev/null 2>&1; do sleep 0.2; done
+  while ! timeout 5 kubectl logs --limit-bytes 32 "job/${job_name}"  > /dev/null 2>&1; do sleep 0.2; done
 
   # Run kubectl logs --follow in a loop since it can still fail:
   #   1) It can fail due to pod not being initialized yet: "Error from server (BadRequest): container "step" in pod "somepod" is waiting to start: PodInitializing"

--- a/hooks/command
+++ b/hooks/command
@@ -23,8 +23,9 @@ function tail_logs {
   # logs will be failing until they're available for streaming, once available we actually start streaming them.
   while ! kubectl logs --tail 0 --limit-bytes 1 "job/${job_name}" > /dev/null 2>&1; do sleep 0.2; done
 
-  # It can fail even after we get the first result, so run it in loop (potentially allowing log to be displayed multple times, but chance is low).
-  while ! kubectl logs --follow "job/${job_name}"; do sleep 0.2; done
+  # It can fail even after we get the first result, so run it in loop (potentially allowing log to be displayed multiple times, but chance is low).
+  # Example of a failure: "Error from server (BadRequest): container "step" in pod "somepod" is waiting to start: PodInitializing"
+  while ! kubectl logs --follow "job/${job_name}" 2>/dev/null; do sleep 0.2; done
 }
 
 echo "--- :kubernetes: Starting Kubernetes Job"


### PR DESCRIPTION
Hi, thanks for this plugin, it does a great job of heavy-lifting k8s jobs integration and is easy (-ish haha) to work with 👍 

This PR fixes the problem we observe in all jobs — logs are repeated 2, 3, 4 or more times.

With this change it'll display `kubectl logs --follow` only once instead unless in-flight `logs --follow` fails.