### PR TITLE
Add option to use the same tolerations as agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ Sets [memory request](https://kubernetes.io/docs/concepts/configuration/manage-c
 
 Sets [memory limit](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) for the build container.
 
+### `use-agent-node-affinity` (optional, boolean)
+
+If set to `true`, the spawned jobs will use the same [node affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) and [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) as the buildkite agent.
+
 ### `workdir` (optional, string)
 
 Override the working directory to run the command in, inside the container. The default is the build directory where the buildkite bootstrap and git checkout runs.

--- a/hooks/command
+++ b/hooks/command
@@ -31,13 +31,21 @@ echo "--- :kubernetes: Starting Kubernetes Job"
 
 export patchFunc=${BUILDKITE_PLUGIN_K8S_PATCH:-"function(f) f"}
 
-jsonnet \
+jobspec=$(jsonnet \
   --tla-str "jobName=${job_name}" \
   --tla-str-file "stepEnvFile=${BUILDKITE_ENV_FILE}" \
   --tla-code "agentEnv=$(jq -c -n env)" \
   --tla-code patchFunc \
-  "${basedir}/lib/job.jsonnet" \
-  | kubectl apply -f -
+  "${basedir}/lib/job.jsonnet")
+
+if [[ "$BUILDKITE_PLUGIN_K8S_USE_AGENT_NODE_AFFINITY" == 'true' ]]; then
+  for field in affinity tolerations; do
+    buildkite_agent_value=$(kubectl get pod "$(cat /etc/hostname)" -o json | jq ".spec.$field")
+    jobspec=$(echo "$jobspec" | jq ".spec.template.spec.$field=$buildkite_agent_value")
+  done
+fi
+
+echo "$jobspec" | kubectl apply -f -
 
 echo "Timeout: ${timeout}s"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -57,6 +57,8 @@ configuration:
       type: string
     resources-limit-memory:
       type: string
+    use-agent-node-affinity:
+      type: boolean
   required:
   - image
   additionalProperties: false


### PR DESCRIPTION
As a shorthand, in place of manually providing the same values
in each pipeline configuration as a jsonpatch object.