### PR TITLE
Fix pipeline build and publish image step

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,14 +13,16 @@ steps:
   - name: Build and publish k8s-buildkite-agent container image
     branches: 'master'
     agents:
-      queue: default
+      queue: monorepo-ci
       os: linux
     plugins:
-      - EmbarkStudios/k8s#1.0.1:
+      - EmbarkStudios/k8s#1.2.6:
           image: gcr.io/kaniko-project/executor:latest
+          default-secret-name: buildkite-k8s-plugin
+          use-agent-node-affinity: true
           command:
             - --destination=embarkstudios/k8s-buildkite-agent
-            - --context=dir://$PWD
+            - --context=.
             - --reproducible
             - --cache=true
             - --cache-repo=kaniko-cache.buildkite.svc.cluster.local/kaniko/cache


### PR DESCRIPTION
* Use ci agents queues to run pipeline
* Update plugin version to 1.2.6
* Set PWD context properly
  Using $PWD will set context to the pwd (containing the host name) on
  the buildkite-agent that launches the plugin which isn't
  necesarily on the same node that the created job runs on so it
  fails sometimes with a file not found
  e.g(/buildkite/<hostname>/k8s-buildkite-plugin/Dockerfile)