### PR TITLE
Also allow `BUILDKITE` env variable

### DIFF
--- a/lib/job.jsonnet
+++ b/lib/job.jsonnet
@@ -1,5 +1,6 @@
 local allowedEnvs = std.set(
   [
+    'BUILDKITE',
     'BUILDKITE_AGENT_ACCESS_TOKEN',
     'BUILDKITE_JOB_ID',
     'BUILDKITE_REPO',


### PR DESCRIPTION
Spent a while debugging this for a third-party tool that wasn't recognizing buildkite.