### PR TITLE
Fix null exits

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -221,6 +221,11 @@ else
       status="42"
     else
       echo "$pod_json" >&2
+
+      container_status="$(echo "$pod_json" | jq -e ".status.containerStatuses[0].state.terminated.exitCode")"
+      if [[ $? -eq 0 ]]; then
+        status=$container_status
+      fi
     fi
     set -e
 


### PR DESCRIPTION
When the init container doesn't ever start and the job times out, the
result from the jq above is null

```
/buildkite/plugins/github-com-EmbarkStudios-k8s-buildkite-plugin-git-a51da48f6871e47b3bccd41640b7553ecece3a56/hooks/command: line 214: exit: null: numeric argument required
```