### PR TITLE
Change pod creation timeout to unique exit code

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -139,7 +139,7 @@ do
     sleep "$job_status_retry_interval_sec"
     if [[ $timeout -gt 0 ]]; then
       if ! (( counter -= job_status_retry_interval_sec )); then
-        echo "Warning: pod wasn't created before timeout"
+        echo "Warning: timed out while creating pod"
         exit 42
       fi
     fi

--- a/hooks/command
+++ b/hooks/command
@@ -204,8 +204,8 @@ else
       sleep "$job_status_retry_interval_sec"
       if [[ $timeout -gt 0 ]]; then
         if ! (( counter -= job_status_retry_interval_sec )); then
-          echo "Warning: never successfully got pod status"
-          exit 42
+          echo "Warning: timed out while checking init container status"
+          break;
         fi
       fi
     fi

--- a/hooks/command
+++ b/hooks/command
@@ -138,10 +138,10 @@ do
   else
     sleep "$job_status_retry_interval_sec"
     if [[ $timeout -gt 0 ]]; then
-      if ! (( counter -= job_status_retry_interval_sec )); then
+      (( counter -= job_status_retry_interval_sec )) || {
         echo "Warning: timed out while creating pod"
         exit 42
-      fi
+      }
     fi
   fi
 done
@@ -203,10 +203,10 @@ else
     else
       sleep "$job_status_retry_interval_sec"
       if [[ $timeout -gt 0 ]]; then
-        if ! (( counter -= job_status_retry_interval_sec )); then
+        (( counter -= job_status_retry_interval_sec )) || {
           echo "Warning: timed out while checking init container status"
-          break;
-        fi
+          break
+        }
       fi
     fi
   done

--- a/hooks/command
+++ b/hooks/command
@@ -138,7 +138,10 @@ do
   else
     sleep "$job_status_retry_interval_sec"
     if [[ $timeout -gt 0 ]]; then
-      (( counter -= job_status_retry_interval_sec ))
+      if ! (( counter -= job_status_retry_interval_sec )); then
+        echo "Warning: pod wasn't created before timeout"
+        exit 42
+      fi
     fi
   fi
 done
@@ -200,7 +203,10 @@ else
     else
       sleep "$job_status_retry_interval_sec"
       if [[ $timeout -gt 0 ]]; then
-        (( counter -= job_status_retry_interval_sec ))
+        if ! (( counter -= job_status_retry_interval_sec )); then
+          echo "Warning: never successfully got pod status"
+          exit 42
+        fi
       fi
     fi
   done


### PR DESCRIPTION
If the pod isn't created before the timeout is reached, this adds a
unique exit code so users can automatically retry in this case. Without
this it exits 1 which is difficult to differentiate between a real job
error in most cases. Ideally buildkite would show a timeout in this case
since this timeout is derived from that, but it's seems to race that