### PR TITLE
Get job status when pod doesn't exist

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -136,6 +136,14 @@ do
   if [[ -n "$pod_name" ]]; then
     break
   else
+    set +e
+    jobstatus=$(kubectl get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
+    set -e
+    if [[ "$jobstatus" == "Failed" ]]; then
+      echo "Warning: job failed to create pod"
+      exit 42
+    fi
+
     sleep "$job_status_retry_interval_sec"
     if [[ $timeout -gt 0 ]]; then
       (( counter -= job_status_retry_interval_sec ))

--- a/hooks/command
+++ b/hooks/command
@@ -140,7 +140,7 @@ do
     jobstatus=$(kubectl get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
     set -e
     if [[ "$jobstatus" == "Failed" ]]; then
-      echo "Warning: job failed to create pod"
+      echo "Warning: exiting because no pod was found and job status was Failed"
       exit 42
     fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -126,22 +126,28 @@ echo "Timeout: ${timeout}s"
 
 echo "--- :kubernetes: Running image: ${BUILDKITE_PLUGIN_K8S_IMAGE}"
 
+error_file=$(mktemp)
 counter="$timeout"
 while true
 do
+  echo -n > "$error_file"
   set +e
-  pod_name=$(kubectl get pod -l "job-name=$job_name" --output=jsonpath="{.items[*].metadata.name}")
+  pod_name=$(kubectl get pod -l "job-name=$job_name" --output=jsonpath="{.items[*].metadata.name}" 2>"$error_file")
   set -e
 
   if [[ -n "$pod_name" ]]; then
     break
   else
-    set +e
-    jobstatus=$(kubectl get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
-    set -e
-    if [[ "$jobstatus" == "Failed" ]]; then
-      echo "Warning: exiting because no pod was found and job status was Failed"
-      exit 42
+    if grep -q NotFound "$error_file"; then
+      set +e
+      jobstatus=$(kubectl get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
+      set -e
+      if [[ "$jobstatus" == "Failed" ]]; then
+        echo "Warning: exiting because no pod was found and job status was Failed"
+        exit 42
+      fi
+    elif [[ -s "$error_file" ]]; then
+      cat "$error_file" >&2
     fi
 
     sleep "$job_status_retry_interval_sec"

--- a/hooks/command
+++ b/hooks/command
@@ -126,19 +126,16 @@ echo "Timeout: ${timeout}s"
 
 echo "--- :kubernetes: Running image: ${BUILDKITE_PLUGIN_K8S_IMAGE}"
 
-error_file=$(mktemp)
 counter="$timeout"
 while true
 do
-  echo -n > "$error_file"
+  exit_status=0
   set +e
-  pod_name=$(kubectl get pod -l "job-name=$job_name" --output=jsonpath="{.items[*].metadata.name}" 2>"$error_file")
+  pod_name=$(kubectl get pod -l "job-name=$job_name" --output=jsonpath="{.items[*].metadata.name}" 2>&1)
+  exit_status=$?
   set -e
 
-  if [[ -n "$pod_name" ]]; then
-    break
-  else
-    if grep -q NotFound "$error_file"; then
+  if [[ $exit_status -ne 0 && "$pod_name" == *NotFound* ]]; then
       set +e
       jobstatus=$(kubectl get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
       set -e
@@ -146,10 +143,11 @@ do
         echo "Warning: exiting because no pod was found and job status was Failed"
         exit 42
       fi
-    elif [[ -s "$error_file" ]]; then
-      cat "$error_file" >&2
-    fi
+  fi
 
+  if [[ -n "$pod_name" ]]; then
+    break
+  else
     sleep "$job_status_retry_interval_sec"
     if [[ $timeout -gt 0 ]]; then
       (( counter -= job_status_retry_interval_sec ))


### PR DESCRIPTION
In the case a pod is scheduled on a node, then evicted, you can end up
in a state where you search for the pod forever when the job was already
know to have failed:

```
Error from server (NotFound): pods "ios-714750-zjyo7cyw-gsnzh" not found
Error from server (NotFound): pods "ios-714750-zjyo7cyw-gsnzh" not found
Error from server (NotFound): pods "ios-714750-zjyo7cyw-gsnzh" not found
Error from server (NotFound): pods "ios-714750-zjyo7cyw-gsnzh" not found
Error from server (NotFound): pods "ios-714750-zjyo7cyw-gsnzh" not found
```

This checks the job status and exits if it has failed in that case