### PR TITLE
Skip plugin on non-Linux systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,12 @@ env:
 - Default: `60`
 - Unit type: integer seconds
 
+### BUILDKITE_PLUGIN_K8S_SKIP_ON_MACOS
+
+- Skips all plugin logic on macOS to allow configuration that runs on multiple platforms
+- Default: `false`
+- Unit type: boolean
+
 ## Contributing
 
 We welcome community contributions to this project.

--- a/README.md
+++ b/README.md
@@ -331,12 +331,6 @@ env:
 - Default: `60`
 - Unit type: integer seconds
 
-### BUILDKITE_PLUGIN_K8S_SKIP_ON_MACOS
-
-- Skips all plugin logic on macOS to allow configuration that runs on multiple platforms
-- Default: `false`
-- Unit type: boolean
-
 ## Contributing
 
 We welcome community contributions to this project.

--- a/hooks/command
+++ b/hooks/command
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+if [[ $OSTYPE == darwin* ]]; then
+  exec /bin/bash -c "$BUILDKITE_COMMAND"
+fi
+
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
 # Ensure a name is a valid k8s resource name.
@@ -29,11 +33,6 @@ readonly log_complete_timeout_sec="${BUILDKITE_PLUGIN_K8S_LOG_COMPLETE_TIMEOUT_S
 readonly use_agent_node_affinity=${BUILDKITE_PLUGIN_K8S_USE_AGENT_NODE_AFFINITY:-false}
 readonly print_resulting_job_spec=${BUILDKITE_PLUGIN_K8S_PRINT_RESULTING_JOB_SPEC:-false}
 readonly jobs_cleanup_via_plugin=${BUILDKITE_PLUGIN_K8S_JOBS_CLEANUP_VIA_PLUGIN:-}
-readonly skip_on_macos=${BUILDKITE_PLUGIN_K8S_SKIP_ON_MACOS:-}
-
-if [[ "$skip_on_macos" == "true" && $OSTYPE == darwin* ]]; then
-  exec /bin/bash -c "$BUILDKITE_COMMAND"
-fi
 
 bootstrap_container_log_complete_marker_file="$(mktemp)"
 readonly bootstrap_container_log_complete_marker_file

--- a/hooks/command
+++ b/hooks/command
@@ -29,6 +29,11 @@ readonly log_complete_timeout_sec="${BUILDKITE_PLUGIN_K8S_LOG_COMPLETE_TIMEOUT_S
 readonly use_agent_node_affinity=${BUILDKITE_PLUGIN_K8S_USE_AGENT_NODE_AFFINITY:-false}
 readonly print_resulting_job_spec=${BUILDKITE_PLUGIN_K8S_PRINT_RESULTING_JOB_SPEC:-false}
 readonly jobs_cleanup_via_plugin=${BUILDKITE_PLUGIN_K8S_JOBS_CLEANUP_VIA_PLUGIN:-}
+readonly skip_on_macos=${BUILDKITE_PLUGIN_K8S_SKIP_ON_MACOS:-}
+
+if [[ "$skip_on_macos" == "true" && $OSTYPE == darwin* ]]; then
+  exec /bin/bash -c "$BUILDKITE_COMMAND"
+fi
 
 bootstrap_container_log_complete_marker_file="$(mktemp)"
 readonly bootstrap_container_log_complete_marker_file

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-readonly skip_on_macos=${BUILDKITE_PLUGIN_K8S_SKIP_ON_MACOS:-}
-if [[ "$skip_on_macos" == "true" && $OSTYPE == darwin* ]]; then
+if [[ $OSTYPE == darwin* ]]; then
   exit 0
 fi
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+readonly skip_on_macos=${BUILDKITE_PLUGIN_K8S_SKIP_ON_MACOS:-}
+if [[ "$skip_on_macos" == "true" && $OSTYPE == darwin* ]]; then
+  exit 0
+fi
+
 job_name="$(cat /tmp/job_name)"
 
 echo "--- :kubernetes: Cleanup"


### PR DESCRIPTION
This allows you to have a single configuration for jobs that support multiple platforms but you don't want to run this plugin on some of them