### PR TITLE
Improve env string parsing

### DIFF
--- a/lib/job.jsonnet
+++ b/lib/job.jsonnet
@@ -84,11 +84,9 @@ function(jobName, agentEnv={}, stepEnvFile='', patchFunc=identity) patchFunc({
   local stepEnv =
     [
       {
-        local trim(v) = if std.startsWith(v, '"') && std.endsWith(v, '"')
-          then std.substr(v, 1, std.length(v) - 2) else v,
         local kv = std.splitLimit(l, '=', 1),
         name: kv[0],
-        value: trim(kv[1]),
+        value: std.parseJson(kv[1]),
       }
       for l in std.split(stepEnvFile, '\n')
       if l != '' && !std.startsWith(l, 'BUILDKITE')


### PR DESCRIPTION
In https://github.com/EmbarkStudios/k8s-buildkite-plugin/pull/30 I fixed the common case where an env var like:

```
FOO="bar"
```

Ended up in the json as:

```
{
   "name": "FOO",
   "value": "\"BAR\""
}
```

This change improves another case where the escaped quotes are further
nested like:

```
FOO="{\"baz\": \"qux\"}"
```

Previously these would end up in the json as:

```
{
   "name": "FOO",
   "value": "{\\\"baz\\\": \\\"qux\\\"}"
}
```

With this change they correctly end up in the json as:

```
{
   "name": "FOO",
   "value": "{\"baz\": \"qux\"}"
}
```

It feels like a hack to assume that all strings will parse with this this function, but it seems to work correctly as a string parser as well.