### PR TITLE
Fix k8s labels ending in invalid characters

### DIFF
--- a/lib/job.jsonnet
+++ b/lib/job.jsonnet
@@ -39,10 +39,10 @@ local numberSuffix(s) =
   local t = std.split(s, '_');
   std.format('%05s', t[std.length(t) - 1]);
 
-local labelChars = std.set(std.stringChars('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.'));
+local labelChars = std.set(std.stringChars('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'));
 local labelValue(s) =
   local sanitizedValue = std.join('', [
-    if std.setMember(c, labelChars) then c else '_'
+    if std.setMember(c, labelChars) then c else ''
     for c in std.stringChars(s)
   ]);
   if std.length(sanitizedValue) < 63 then sanitizedValue else std.substr(sanitizedValue, 0, 63);


### PR DESCRIPTION
If your branch was > 63 characters long, we would truncate it, if the
truncation ended in a non-alpha numeric character, k8s fails.

This removes those characters entirely from these labels, which
theoretically increases the chances of collisions, but I think it's
unlikely enough that this is fine. Alternatively we can be smarter about
it just starting with or ending with the other characters, but that's
just a bit more logic to deal with.

```
* spec.template.labels: Invalid value: “transittripui-include-questions-debug-description-to-assertion-“: a valid label must be an empty string or consist of alphanumeric characters, ‘-’, ‘_’ or ‘.’, and must start and end with an alphanumeric character (e.g. ‘MyValue’,  or ‘my_value’,  or ‘12345’, regex used for validation is ‘(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?’)
```

The other case of sanitization like this should be less likely to be
impacted since it only includes the pipeline name and build number