### PR TITLE
Fix pipeline queue

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,7 +1,7 @@
 steps:
   - name: shellcheck hooks
     agents:
-      queue: default
+      queue: monorepo-ci
       os: linux
     command:
       - echo "Running shellcheck"


### PR DESCRIPTION
I think we've removed the 'default' queue recently so the shellcheck step
in the pipeline is waiting indefinitely for a matching agent to pick it
up.