### PR TITLE
Do not mount buildkite-agent when building CI image with Kaniko

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -20,14 +20,29 @@ steps:
     plugins:
       - EmbarkStudios/k8s#1.2.6:
           image: gcr.io/kaniko-project/executor:latest
+          mount-buildkite-agent: false
           default-secret-name: buildkite-k8s-plugin
           use-agent-node-affinity: true
           command:
             - --destination=embarkstudios/k8s-buildkite-agent
             - --context=.
             - --reproducible
-            - --cache=true
-            - --cache-repo=kaniko-cache.buildkite.svc.cluster.local/kaniko/cache
-            - --cache-dir=$BUILDKITE_BUILD_PATH/_kaniko_cache
+          mount-secret:
+            - docker-hub-credentials:/kaniko/.docker
+  - name: Build and publish k8s-buildkite-agent CI-debug container image
+    branches: '!master'
+    agents:
+      queue: monorepo-ci
+      os: linux
+    plugins:
+      - EmbarkStudios/k8s#1.2.6:
+          image: gcr.io/kaniko-project/executor:latest
+          mount-buildkite-agent: false
+          default-secret-name: buildkite-k8s-plugin
+          use-agent-node-affinity: true
+          command:
+            - --destination=embarkstudios/k8s-buildkite-agent:ci-debug
+            - --context=.
+            - --reproducible
           mount-secret:
             - docker-hub-credentials:/kaniko/.docker

--- a/hooks/command
+++ b/hooks/command
@@ -39,6 +39,7 @@ readonly bootstrap_container_log_complete_marker_file
 step_container_log_complete_marker_file="$(mktemp)"
 readonly step_container_log_complete_marker_file
 
+# shellcheck disable=2317 # Shellcheck doesn't understand traps
 function cleanup {
   rm -f "$bootstrap_container_log_complete_marker_file" "$step_container_log_complete_marker_file"
 


### PR DESCRIPTION
Kaniko will mount some extra host directories into the build context. All files included in that context will be forbidden from being added to layers, and Kaniko will silently drop them from the build. Since we use kaniko from inside the plugin, we mounted the "host" buildkite-agent, which prevented the COPY command from copying the multistage sourced buildkite-agent (since it thought we tried to copy the host buildkite-agent). Very confusing. 

Should help #56.

Also adds a non-master build-step to build debug-ci images, to avoid interacting with :latest 