### PR TITLE
gracefully handle teams being missing

### DIFF
--- a/lib/job.jsonnet
+++ b/lib/job.jsonnet
@@ -115,7 +115,6 @@ function(jobName, agentEnv={}, stepEnvFile='', patchFunc=identity) patchFunc({
     'build/commit': env.BUILDKITE_COMMIT,
     'build/creator': env.BUILDKITE_BUILD_CREATOR,
     'build/creator-email': env.BUILDKITE_BUILD_CREATOR_EMAIL,
-    'build/creator-teams': env.BUILDKITE_BUILD_CREATOR_TEAMS,
     'build/id': env.BUILDKITE_BUILD_ID,
     'build/url': env.BUILDKITE_BUILD_URL,
     'build/number': env.BUILDKITE_BUILD_NUMBER,
@@ -128,6 +127,7 @@ function(jobName, agentEnv={}, stepEnvFile='', patchFunc=identity) patchFunc({
     'buildkite/step-id': env.BUILDKITE_STEP_ID,
     'buildkite/step-key': env.BUILDKITE_STEP_KEY,
     'job-name': jobName,
+    [if std.objectHas(env, "BUILDKITE_BUILD_CREATOR_TEAMS") then 'build/creator-teams' else null]: env.BUILDKITE_BUILD_CREATOR_TEAMS,
   },
 
   local buildVolume =
@@ -274,7 +274,7 @@ function(jobName, agentEnv={}, stepEnvFile='', patchFunc=identity) patchFunc({
 
   local deadline = std.parseInt(env.BUILDKITE_TIMEOUT) * 60,
 
-  local imagePullSecrets = 
+  local imagePullSecrets =
     if env.BUILDKITE_PLUGIN_K8S_IMAGE_PULL_SECRET == '' then []
     else [
         {name: env.BUILDKITE_PLUGIN_K8S_IMAGE_PULL_SECRET},


### PR DESCRIPTION
This ensures we remove the annotation when the teams feature isn't enabled. I think this is better than leaving it empty, which is admittedly less code.