### PR TITLE
Do not run plugin inside itself

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -6,6 +6,11 @@ if [[ $OSTYPE == darwin* ]]; then
   exec /bin/bash -c "$BUILDKITE_COMMAND"
 fi
 
+if [[ -v "BUILDKITE_PLUGIN_K8S_IS_JOB" ]]; then
+	# do not recurse
+	exit 0
+fi
+
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
 # Ensure a name is a valid k8s resource name.

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -6,6 +6,11 @@ if [[ $OSTYPE == darwin* ]]; then
   exit 0
 fi
 
+if [[ -v "BUILDKITE_PLUGIN_K8S_IS_JOB" ]]; then
+	# do not recurse
+	exit 0
+fi
+
 job_name="$(cat /tmp/job_name)"
 
 echo "--- :kubernetes: Cleanup"

--- a/lib/job.jsonnet
+++ b/lib/job.jsonnet
@@ -89,6 +89,8 @@ function(jobName, agentEnv={}, stepEnvFile='', patchFunc=identity) patchFunc({
       for f in std.sort(std.objectFields(env), numberSuffix)
       if std.startsWith(f, 'BUILDKITE_PLUGIN_K8S_ENVIRONMENT_')
          && !std.startsWith(f, 'BUILDKITE_PLUGIN_K8S_ENVIRONMENT_FROM_SECRET')
+    ] + [
+      'BUILDKITE_PLUGIN_K8S_IS_JOB': 'true',
     ],
 
   local secretEnv =
@@ -274,7 +276,7 @@ function(jobName, agentEnv={}, stepEnvFile='', patchFunc=identity) patchFunc({
 
   local deadline = std.parseInt(env.BUILDKITE_TIMEOUT) * 60,
 
-  local imagePullSecrets = 
+  local imagePullSecrets =
     if env.BUILDKITE_PLUGIN_K8S_IMAGE_PULL_SECRET == '' then []
     else [
         {name: env.BUILDKITE_PLUGIN_K8S_IMAGE_PULL_SECRET},


### PR DESCRIPTION
@keith - This seems to be a bug introduced in #45 where the plugin gets runs again inside the init container, and so each job spawns another nested job. I believe this is triggered by forwarding BUILDKITE_PLUGINS, which I do think we should support running inside the init container in general. I assume you do not run with an init container?