### PR TITLE
Mark CI job pods as NOT safe to evict for ClusterAutoscaler

### DIFF
--- a/lib/job.jsonnet
+++ b/lib/job.jsonnet
@@ -299,7 +299,11 @@ function(jobName, agentEnv={}, stepEnvFile='', patchFunc=identity) patchFunc({
         labels: labels,
         # Take all the same annotations as the job itself on the pod, but also add the istio inject false annotation
         # Istio gets in the way of many jobs
-        annotations: annotations { 'sidecar.istio.io/inject': 'false' },
+        # Mark Pod as NOT safe to evict for ClusterAutoscaler during cluster scale up/down.
+        annotations: annotations {
+          'sidecar.istio.io/inject': 'false',
+          'cluster-autoscaler.kubernetes.io/safe-to-evict': 'false'
+        },
       },
       spec: {
         activeDeadlineSeconds: deadline,


### PR DESCRIPTION
We've recently made our ClusterAutoscaler more aggressive and it started to kill running CI Job Pods during cluster scale up/down events thinking that CI Job Pod will restart and finish on another Node which is not true.

Looking for ways to prevent this I've tried working with PodDisruptionBudget as per K8S docs https://kubernetes.io/docs/tasks/run-application/configure-pdb/, however K8S Jobs don't support PDB, so the only working way we've found is to set `cluster-autoscaler.kubernetes.io/safe-to-evict: false` annotation on K8S Job Pods.

With this annotation ClusterAutoscaler can still scale Nodes Up/Down but it will wait for CI Job Pods to safely finish before removing a Node instead of just killing the Pods as it wants disrupting the CI flow.