### PR TITLE
Wrap kubectl calls to properly output an error

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -12,7 +12,6 @@ if [[ -v "BUILDKITE_PLUGIN_K8S_IS_JOB" ]]; then
 fi
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
-source "${basedir}/lib/kubectl.sh"
 
 # Ensure a name is a valid k8s resource name.
 function sanitize() {
@@ -59,7 +58,7 @@ function cleanup {
 
   if [[ "$jobs_cleanup_via_plugin" == "true" ]]; then
     # Delete all jobs older than a day.
-    kubectl_wrapper delete job "$(kubectl_wrapper get job -l buildkite/plugin=k8s | awk 'match($4,/[0-9]+d/) {print $1}')" 2>/dev/null || true
+    "$basedir/lib/kubectl_wrapper.sh" delete job "$($basedir/lib/kubectl_wrapper.sh get job -l buildkite/plugin=k8s | awk 'match($4,/[0-9]+d/) {print $1}')" 2>/dev/null || true
   fi
 }
 
@@ -76,7 +75,7 @@ function tail_logs {
   while true;
   do
     set +e
-    log_snapshot="$(timeout "$log_attempt_timeout_sec" kubectl_wrapper logs --limit-bytes "1024" "pod/$pod_name" --container "$container_name" 2>/dev/null)"
+    log_snapshot="$(timeout "$log_attempt_timeout_sec" "$basedir/lib/kubectl_wrapper.sh" logs --limit-bytes "1024" "pod/$pod_name" --container "$container_name" 2>/dev/null)"
     set -e
     if [[ -n "$log_snapshot" ]]; then
       break
@@ -88,7 +87,7 @@ function tail_logs {
   #   1) It can fail due to pod not being initialized yet: "Error from server (BadRequest): container "step" in pod "somepod" is waiting to start: PodInitializing"
   #   2) It can fail mid-streaming, in this case we unfortunately will display logs multiple times (partially).
   #   3) It can hang not providing any result, that's why we check not only exit code but also contents in the loop above.
-  while ! kubectl_wrapper logs --follow "pod/$pod_name" --container "$container_name" 2>/dev/null;
+  while ! "$basedir/lib/kubectl_wrapper.sh" logs --follow "pod/$pod_name" --container "$container_name" 2>/dev/null;
   do
     sleep "$log_loop_retry_interval_sec"
   done
@@ -101,7 +100,7 @@ if [[ -n $external_secrets || -n $external_secrets_list || -n $secret_store || -
   echo "--- :kubernetes: Creating Secrets"
 
   # Check if the ExternalSecrets CRD exists
-  if [[ -z $(kubectl_wrapper get crd externalsecrets.external-secrets.io 2>/dev/null) ]]; then
+  if [[ -z $("$basedir/lib/kubectl_wrapper.sh" get crd externalsecrets.external-secrets.io 2>/dev/null) ]]; then
     echo "External Secrets CRD not found. Is the External Secrets Operator installed in the cluster?" >&2
     exit 42
   fi
@@ -142,14 +141,14 @@ if [[ -n $external_secrets || -n $external_secrets_list || -n $secret_store || -
   readonly secret_apply_end_time=$((SECONDS+30))
 
   set +e
-  echo "$external_secret_spec" | kubectl_wrapper apply -f -
+  echo "$external_secret_spec" | "$basedir/lib/kubectl_wrapper.sh" apply -f -
   set -e
 
   echo "Waiting for Secret to become available"
   while [ $SECONDS -lt $secret_apply_end_time ]; do
     # Check if the secret exists
-    secret_exists=$(kubectl_wrapper get secret "$job_name" > /dev/null 2>&1; echo $?)
-    external_secret_status=$(kubectl_wrapper get ExternalSecret "$job_name" -o json | jq -r '.status.conditions[0].status')
+    secret_exists=$("$basedir/lib/kubectl_wrapper.sh" get secret "$job_name" > /dev/null 2>&1; echo $?)
+    external_secret_status=$("$basedir/lib/kubectl_wrapper.sh" get ExternalSecret "$job_name" -o json | jq -r '.status.conditions[0].status')
     if [ "$secret_exists" != 1 ] && [ "$external_secret_status" == "True" ]; then
       echo "Secret Created"
       break
@@ -158,7 +157,7 @@ if [[ -n $external_secrets || -n $external_secrets_list || -n $secret_store || -
 
   if [ "$secret_exists" == 1 ] || [ "$external_secret_status" != "True" ]; then
     echo "Secret creation failed, check ExternalSecrets logs in your cluster"
-    status=$(kubectl_wrapper get ExternalSecret "$job_name" -o json | jq -r '.status.conditions[0].message')
+    status=$("$basedir/lib/kubectl_wrapper.sh" get ExternalSecret "$job_name" -o json | jq -r '.status.conditions[0].message')
     echo "External Secret Status: $status"
     return 42
   fi
@@ -178,7 +177,7 @@ job_spec="$(jsonnet \
   "${basedir}/lib/job.jsonnet")"
 
 if [[ "$use_agent_node_affinity" == "true" ]]; then
-  agent_spec="$(kubectl_wrapper get pod "$(cat /etc/hostname)" -o json)"
+  agent_spec="$("$basedir/lib/kubectl_wrapper.sh" get pod "$(cat /etc/hostname)" -o json)"
   for field in affinity tolerations nodeSelector; do
     agent_value=$(echo "$agent_spec" | jq ".spec.$field")
     job_spec="$(echo "$job_spec" | jq ".spec.template.spec.$field=$agent_value")"
@@ -195,7 +194,7 @@ job_apply_exit_code=""
 while [[ "$((SECONDS - job_apply_start_time))" -lt "$job_apply_timeout_sec" ]]
 do
   set +e
-  echo "$job_spec" | kubectl_wrapper apply -f -
+  echo "$job_spec" | "$basedir/lib/kubectl_wrapper.sh" apply -f -
   job_apply_exit_code="$?"
   set -e
 
@@ -221,13 +220,13 @@ while true
 do
   exit_status=0
   set +e
-  pod_name=$(kubectl_wrapper get pod -l "job-name=$job_name" --output=jsonpath="{.items[*].metadata.name}" 2>&1)
+  pod_name=$("$basedir/lib/kubectl_wrapper.sh" get pod -l "job-name=$job_name" --output=jsonpath="{.items[*].metadata.name}" 2>&1)
   exit_status=$?
   set -e
 
   if [[ $exit_status -ne 0 && "$pod_name" == *NotFound* ]]; then
       set +e
-      jobstatus=$(kubectl_wrapper get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
+      jobstatus=$("$basedir/lib/kubectl_wrapper.sh" get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
       set -e
       if [[ "$jobstatus" == "Failed" ]]; then
         echo "Warning: exiting because no pod was found and job status was Failed"
@@ -263,7 +262,7 @@ counter="$timeout"
 jobstatus=""
 while [[ -z "$jobstatus" ]] ; do
   set +e
-  jobstatus=$(kubectl_wrapper get job "${job_name}" -o 'jsonpath={.status.conditions[].type}')
+  jobstatus=$("$basedir/lib/kubectl_wrapper.sh" get job "${job_name}" -o 'jsonpath={.status.conditions[].type}')
   set -e
 
   if [[ -n "$jobstatus" ]]; then
@@ -294,7 +293,7 @@ else
   while true
   do
     set +e
-    pod_json=$(kubectl_wrapper get pod "$pod_name" -o json 2>&1)
+    pod_json=$("$basedir/lib/kubectl_wrapper.sh" get pod "$pod_name" -o json 2>&1)
     get_pod_status=$?
     if [[ "$get_pod_status" -eq 0 ]]; then
       init_container_status="$(echo "$pod_json" | jq ".status.initContainerStatuses[0].state.terminated.exitCode")"

--- a/hooks/command
+++ b/hooks/command
@@ -12,6 +12,7 @@ if [[ -v "BUILDKITE_PLUGIN_K8S_IS_JOB" ]]; then
 fi
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+source "${basedir}/lib/kubectl.sh"
 
 # Ensure a name is a valid k8s resource name.
 function sanitize() {
@@ -58,7 +59,7 @@ function cleanup {
 
   if [[ "$jobs_cleanup_via_plugin" == "true" ]]; then
     # Delete all jobs older than a day.
-    kubectl delete job "$(kubectl get job -l buildkite/plugin=k8s | awk 'match($4,/[0-9]+d/) {print $1}')" 2>/dev/null || true
+    kubectl_wrapper delete job "$(kubectl_wrapper get job -l buildkite/plugin=k8s | awk 'match($4,/[0-9]+d/) {print $1}')" 2>/dev/null || true
   fi
 }
 
@@ -75,7 +76,7 @@ function tail_logs {
   while true;
   do
     set +e
-    log_snapshot="$(timeout "$log_attempt_timeout_sec" kubectl logs --limit-bytes "1024" "pod/$pod_name" --container "$container_name" 2>/dev/null)"
+    log_snapshot="$(timeout "$log_attempt_timeout_sec" kubectl_wrapper logs --limit-bytes "1024" "pod/$pod_name" --container "$container_name" 2>/dev/null)"
     set -e
     if [[ -n "$log_snapshot" ]]; then
       break
@@ -87,7 +88,7 @@ function tail_logs {
   #   1) It can fail due to pod not being initialized yet: "Error from server (BadRequest): container "step" in pod "somepod" is waiting to start: PodInitializing"
   #   2) It can fail mid-streaming, in this case we unfortunately will display logs multiple times (partially).
   #   3) It can hang not providing any result, that's why we check not only exit code but also contents in the loop above.
-  while ! kubectl logs --follow "pod/$pod_name" --container "$container_name" 2>/dev/null;
+  while ! kubectl_wrapper logs --follow "pod/$pod_name" --container "$container_name" 2>/dev/null;
   do
     sleep "$log_loop_retry_interval_sec"
   done
@@ -100,7 +101,7 @@ if [[ -n $external_secrets || -n $external_secrets_list || -n $secret_store || -
   echo "--- :kubernetes: Creating Secrets"
 
   # Check if the ExternalSecrets CRD exists
-  if [[ -z $(kubectl get crd externalsecrets.external-secrets.io 2>/dev/null) ]]; then
+  if [[ -z $(kubectl_wrapper get crd externalsecrets.external-secrets.io 2>/dev/null) ]]; then
     echo "External Secrets CRD not found. Is the External Secrets Operator installed in the cluster?" >&2
     exit 42
   fi
@@ -141,14 +142,14 @@ if [[ -n $external_secrets || -n $external_secrets_list || -n $secret_store || -
   readonly secret_apply_end_time=$((SECONDS+30))
 
   set +e
-  echo "$external_secret_spec" | kubectl apply -f -
+  echo "$external_secret_spec" | kubectl_wrapper apply -f -
   set -e
 
   echo "Waiting for Secret to become available"
   while [ $SECONDS -lt $secret_apply_end_time ]; do
     # Check if the secret exists
-    secret_exists=$(kubectl get secret "$job_name" > /dev/null 2>&1; echo $?)
-    external_secret_status=$(kubectl get ExternalSecret "$job_name" -o json | jq -r '.status.conditions[0].status')
+    secret_exists=$(kubectl_wrapper get secret "$job_name" > /dev/null 2>&1; echo $?)
+    external_secret_status=$(kubectl_wrapper get ExternalSecret "$job_name" -o json | jq -r '.status.conditions[0].status')
     if [ "$secret_exists" != 1 ] && [ "$external_secret_status" == "True" ]; then
       echo "Secret Created"
       break
@@ -157,7 +158,7 @@ if [[ -n $external_secrets || -n $external_secrets_list || -n $secret_store || -
 
   if [ "$secret_exists" == 1 ] || [ "$external_secret_status" != "True" ]; then
     echo "Secret creation failed, check ExternalSecrets logs in your cluster"
-    status=$(kubectl get ExternalSecret "$job_name" -o json | jq -r '.status.conditions[0].message')
+    status=$(kubectl_wrapper get ExternalSecret "$job_name" -o json | jq -r '.status.conditions[0].message')
     echo "External Secret Status: $status"
     return 42
   fi
@@ -177,7 +178,7 @@ job_spec="$(jsonnet \
   "${basedir}/lib/job.jsonnet")"
 
 if [[ "$use_agent_node_affinity" == "true" ]]; then
-  agent_spec="$(kubectl get pod "$(cat /etc/hostname)" -o json)"
+  agent_spec="$(kubectl_wrapper get pod "$(cat /etc/hostname)" -o json)"
   for field in affinity tolerations nodeSelector; do
     agent_value=$(echo "$agent_spec" | jq ".spec.$field")
     job_spec="$(echo "$job_spec" | jq ".spec.template.spec.$field=$agent_value")"
@@ -194,7 +195,7 @@ job_apply_exit_code=""
 while [[ "$((SECONDS - job_apply_start_time))" -lt "$job_apply_timeout_sec" ]]
 do
   set +e
-  echo "$job_spec" | kubectl apply -f -
+  echo "$job_spec" | kubectl_wrapper apply -f -
   job_apply_exit_code="$?"
   set -e
 
@@ -220,13 +221,13 @@ while true
 do
   exit_status=0
   set +e
-  pod_name=$(kubectl get pod -l "job-name=$job_name" --output=jsonpath="{.items[*].metadata.name}" 2>&1)
+  pod_name=$(kubectl_wrapper get pod -l "job-name=$job_name" --output=jsonpath="{.items[*].metadata.name}" 2>&1)
   exit_status=$?
   set -e
 
   if [[ $exit_status -ne 0 && "$pod_name" == *NotFound* ]]; then
       set +e
-      jobstatus=$(kubectl get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
+      jobstatus=$(kubectl_wrapper get job "$job_name" -o 'jsonpath={.status.conditions[].type}')
       set -e
       if [[ "$jobstatus" == "Failed" ]]; then
         echo "Warning: exiting because no pod was found and job status was Failed"
@@ -262,7 +263,7 @@ counter="$timeout"
 jobstatus=""
 while [[ -z "$jobstatus" ]] ; do
   set +e
-  jobstatus=$(kubectl get job "${job_name}" -o 'jsonpath={.status.conditions[].type}')
+  jobstatus=$(kubectl_wrapper get job "${job_name}" -o 'jsonpath={.status.conditions[].type}')
   set -e
 
   if [[ -n "$jobstatus" ]]; then
@@ -293,7 +294,7 @@ else
   while true
   do
     set +e
-    pod_json=$(kubectl get pod "$pod_name" -o json 2>&1)
+    pod_json=$(kubectl_wrapper get pod "$pod_name" -o json 2>&1)
     get_pod_status=$?
     if [[ "$get_pod_status" -eq 0 ]]; then
       init_container_status="$(echo "$pod_json" | jq ".status.initContainerStatuses[0].state.terminated.exitCode")"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
-source "${basedir}/lib/kubectl.sh"
 
 if [[ $OSTYPE == darwin* ]]; then
   exit 0
@@ -31,7 +30,7 @@ external_secrets_list=${BUILDKITE_PLUGIN_K8S_EXTERNAL_SECRETS_0:-}
 # If External Secrets were used, clean them up
 if [[ -n $external_secrets || -n $external_secrets_list ]]; then
   echo "Deleting ExternalSecrets"
-  kubectl_wrapper delete ExternalSecret "$job_name"
+  "$basedir/lib/kubectl_wrapper.sh" delete ExternalSecret "$job_name"
 fi 
 
 if [[ "$job_cleanup_after_finished_via_plugin" != "true" ]]; then
@@ -43,11 +42,11 @@ job_cleanup_exit_code=""
 while [[ "$((SECONDS - job_cleanup_start_time))" -lt "$job_cleanup_timeout_sec" ]]
 do
   set +e
-  pod=$(kubectl_wrapper get pod --output=name -l "job-name=${job_name}")
+  pod=$("$basedir/lib/kubectl_wrapper.sh" get pod --output=name -l "job-name=${job_name}")
   if [[ -n "${pod}" ]] ; then
-    kubectl_wrapper patch --patch '{"spec":{"activeDeadlineSeconds":1}}' "${pod}"
+    "$basedir/lib/kubectl_wrapper.sh" patch --patch '{"spec":{"activeDeadlineSeconds":1}}' "${pod}"
   fi
-  kubectl_wrapper patch --patch '{"spec":{"activeDeadlineSeconds":1}}' "job/${job_name}"
+  "$basedir/lib/kubectl_wrapper.sh" patch --patch '{"spec":{"activeDeadlineSeconds":1}}' "job/${job_name}"
   job_cleanup_exit_code="$?"
   set -e
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+source "${basedir}/lib/kubectl.sh"
+
 if [[ $OSTYPE == darwin* ]]; then
   exit 0
 fi
@@ -28,7 +31,7 @@ external_secrets_list=${BUILDKITE_PLUGIN_K8S_EXTERNAL_SECRETS_0:-}
 # If External Secrets were used, clean them up
 if [[ -n $external_secrets || -n $external_secrets_list ]]; then
   echo "Deleting ExternalSecrets"
-  kubectl delete ExternalSecret "$job_name"
+  kubectl_wrapper delete ExternalSecret "$job_name"
 fi 
 
 if [[ "$job_cleanup_after_finished_via_plugin" != "true" ]]; then
@@ -40,11 +43,11 @@ job_cleanup_exit_code=""
 while [[ "$((SECONDS - job_cleanup_start_time))" -lt "$job_cleanup_timeout_sec" ]]
 do
   set +e
-  pod=$(kubectl get pod --output=name -l "job-name=${job_name}")
+  pod=$(kubectl_wrapper get pod --output=name -l "job-name=${job_name}")
   if [[ -n "${pod}" ]] ; then
-    kubectl patch --patch '{"spec":{"activeDeadlineSeconds":1}}' "${pod}"
+    kubectl_wrapper patch --patch '{"spec":{"activeDeadlineSeconds":1}}' "${pod}"
   fi
-  kubectl patch --patch '{"spec":{"activeDeadlineSeconds":1}}' "job/${job_name}"
+  kubectl_wrapper patch --patch '{"spec":{"activeDeadlineSeconds":1}}' "job/${job_name}"
   job_cleanup_exit_code="$?"
   set -e
 

--- a/lib/kubectl.sh
+++ b/lib/kubectl.sh
@@ -1,0 +1,20 @@
+# Wrapper for kubectl invocations that prints errors in meaningful way including the kubectl command that was run
+# Otherwise you might see random kubectl errors in your Builkite log without knowing that it came from the kubectl invocation
+# Like "error: You must be logged in to the server (Unauthorized)" appearing in the middle or your build logs.
+function kubectl_wrapper() {
+  local stderr_file=$(mktemp)
+
+  set +e
+  kubectl "$@" 2>"$stderr_file"
+  local kubectl_exit_code=$?
+  set -e
+
+  if [[ "$kubectl_exit_code" != "0" ]]; then
+    echo "Error executing 'kubectl $@':" >&2
+    cat "$stderr_file" >&2
+  fi
+
+  rm -f "$stderr_file"
+
+  return "$kubectl_exit_code"
+}

--- a/lib/kubectl_wrapper.sh
+++ b/lib/kubectl_wrapper.sh
@@ -1,20 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
 # Wrapper for kubectl invocations that prints errors in meaningful way including the kubectl command that was run
 # Otherwise you might see random kubectl errors in your Builkite log without knowing that it came from the kubectl invocation
 # Like "error: You must be logged in to the server (Unauthorized)" appearing in the middle or your build logs.
-function kubectl_wrapper() {
-  local stderr_file=$(mktemp)
 
-  set +e
-  kubectl "$@" 2>"$stderr_file"
-  local kubectl_exit_code=$?
-  set -e
+stderr_file=$(mktemp)
+trap 'rm -f "$stderr_file"' EXIT
 
-  if [[ "$kubectl_exit_code" != "0" ]]; then
-    echo "Error executing 'kubectl $@':" >&2
-    cat "$stderr_file" >&2
-  fi
+set +e
+kubectl "$@" 2>"$stderr_file"
+kubectl_exit_code=$?
+set -e
 
-  rm -f "$stderr_file"
+if [[ "$kubectl_exit_code" != "0" ]]; then
+  echo "Error executing 'kubectl $@':" >&2
+  cat "$stderr_file" >&2
+fi
 
-  return "$kubectl_exit_code"
-}
+exit "$kubectl_exit_code"


### PR DESCRIPTION
We've started experiencing issues with K8S cluster (unrelated to `k8s-buildkite-plugin`) and they slip in as `kubectl` errors in the middle of our build logs on Buildkite like this:

```js
Uploading: /tmp/tmp.N7WoODSLLy/dist/symbols/armeabi-v7a.objdump.gz for arch: armeabi-v7a with sharedObjectName:gl.so to https://upload.bugsnag.com/so-symbol
--
  | error: You must be logged in to the server (Unauthorized)
  | error: You must be logged in to the server (Unauthorized)
  | error: You must be logged in to the server (Unauthorized)
  | error: You must be logged in to the server (Unauthorized)
  | NDK mapping NdkMappings(sharedObjectName=x.so, arch=arm64-v8a, ndkMappingFilePath=/tmp/tmp.N7WoODSLLy/capture_symbols/arm64-v8a.objdump.gz), NdkMappings(sharedObjectName=x.so, arch=armeabi-v7a, ndkMappingFilePath=/tmp/tmp.N7WoODSLLy/capture_symbols/armeabi-v7a.objdump.gz) has been uploaded successfully!
  | ProGuard mapping /tmp/tmp.X9Eev60Pxz has been uploaded successfully!
  | The operation took 27.154 sec.
```

This is due to `k8s-buildkite-plugin` outputting logs in parallel to the `while true` control loops where we check job/pod status, etc and ANY `kubectl` command can fail and print an error that doesn't at all indicate that it is coming from `kubectl` 🙃 

PR wraps all `kubectl` calls, captures `stderr` output and prints it with the `kubectl` command parameters so that it is very clear 

1. `kubectl` failed 
2. What `kubectl` command failed (I've checked the invocations, parameter values don't seem to include any sensitive info like tokens)