### PR TITLE
Fix misleading warning when initContainer is unused.

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -297,7 +297,7 @@ else
     get_pod_status=$?
     if [[ "$get_pod_status" -eq 0 ]]; then
       init_container_status="$(echo "$pod_json" | jq ".status.initContainerStatuses[0].state.terminated.exitCode")"
-      if [[ -n "$init_container_status" && "$init_container_status" != "0" ]]; then
+      if [[ -n "$init_container_status" && "$init_container_status" != "null" && "$init_container_status" != "0" ]]; then
         echo "Warning: init container failed with exit code $init_container_status"
         status="$init_container_status"
       else


### PR DESCRIPTION
- If `"init-image": ""` is used (removes the `bootstrap` step), parsing logic will incorrectly flag a warning since `null` is unchecked.
- This should also fix the associated `exit: null: numeric argument required`.

```
Warning: init container failed with exit code null, this usually indicates plugin misconfiguration or infrastructure failure
/buildkite-data/plugins/github-com-EmbarkStudios-k8s-buildkite-plugin-v1-3-1/hooks/command: line 261: exit: null: numeric argument required
```

