### PR TITLE
Fix potential unbound init-container name.

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -249,11 +249,11 @@ echo "Pod is running: $pod_name"
 
 # not set or not empty - "" disables
 if [[ ! -v "BUILDKITE_PLUGIN_K8S_INIT_IMAGE" || -n "${BUILDKITE_PLUGIN_K8S_INIT_IMAGE}" ]]; then
-    echo "--- :kubernetes: Running init-container image: ${BUILDKITE_PLUGIN_K8S_INIT_IMAGE}"
+    echo "--- :kubernetes: Running init-container image: ${BUILDKITE_PLUGIN_K8S_INIT_IMAGE:-}"
     tail_logs "$pod_name" "bootstrap" "$bootstrap_container_log_complete_marker_file"
 fi
 
-echo "+++ :kubernetes: Running image: ${BUILDKITE_PLUGIN_K8S_IMAGE}"
+echo "+++ :kubernetes: Running image: ${BUILDKITE_PLUGIN_K8S_IMAGE:-}"
 tail_logs "$pod_name" "step" "$step_container_log_complete_marker_file" &
 
 counter="$timeout"


### PR DESCRIPTION
- Fix for `BUILDKITE_PLUGIN_K8S_INIT_IMAGE: unbound variable` reported by https://github.com/EmbarkStudios/k8s-buildkite-plugin/issues/84.